### PR TITLE
Update eleventy-img dependency

### DIFF
--- a/functions/img/index.js
+++ b/functions/img/index.js
@@ -54,10 +54,7 @@ async function handler(event, context) {
       widths: [width || "auto"],
       formats: [imageFormat || "auto"],
       dryRun: true,
-      // This should be re-used already https://github.com/11ty/eleventy-img/issues/117
-      cacheOptions: {
-        dryRun: true
-      }
+      useCache: false,
     });
 
     let format = Object.keys(stats).pop();

--- a/functions/img/index.js
+++ b/functions/img/index.js
@@ -54,6 +54,10 @@ async function handler(event, context) {
       widths: [width || "auto"],
       formats: [imageFormat || "auto"],
       dryRun: true,
+      // This should be re-used already https://github.com/11ty/eleventy-img/issues/117
+      cacheOptions: {
+        dryRun: true
+      }
     });
 
     let format = Object.keys(stats).pop();

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/11ty/api-img#readme",
   "dependencies": {
-    "@11ty/eleventy-img": "^2.0.0",
+    "@11ty/eleventy-img": "^2.0.1",
     "@netlify/functions": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/11ty/api-img#readme",
   "dependencies": {
-    "@11ty/eleventy-img": "^1.0.0",
-    "@netlify/functions": "^0.10.0"
+    "@11ty/eleventy-img": "^2.0.0",
+    "@netlify/functions": "^1.0.0"
   }
 }


### PR DESCRIPTION
* Fix issue with `dryRun: true` still writing files in some cases!

Working demo test case: https://test--netlify-eleventy-api-img.netlify.app/https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fo0o2tn5x%2Fproduction%2F4b8ad925e5b9d27f73570fe19ef7cf2063aebdbd-540x442.png/